### PR TITLE
Feature/#76 my page functions

### DIFF
--- a/src/main/java/gitbal/backend/controller/CommonController.java
+++ b/src/main/java/gitbal/backend/controller/CommonController.java
@@ -5,6 +5,7 @@ import gitbal.backend.entity.dto.JoinRequestDto;
 import gitbal.backend.entity.dto.UserInfoDto;
 import gitbal.backend.security.CustomUserDetails;
 import gitbal.backend.service.LoginService;
+import gitbal.backend.service.MyPageService;
 import gitbal.backend.service.UserInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,21 +22,23 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "공통사항 API(미구현)", description = "공통 기능 사항에 대한 api 명세입니다.")
+@Tag(name = "공통사항 API(로그아웃 제외 구현 완료)", description = "공통 기능 사항에 대한 api 명세입니다.")
 public class CommonController {
 
 
   // TODO : 여기 정보들은 회원가입 제외 전부 로그인한 유저 기준으로 작업 진행해야함
   private final LoginService loginService;
   private final UserInfoService userInfoService;
+  private final MyPageService myPageService;
 
   @PostMapping("/join")
-  @Operation(summary = "회원가입", description = "회원가입을 위한 api입니다.")
+  @Operation(summary = "회원가입 (구현 완료)", description = "회원가입을 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "회원가입에 성공했습니다."),
   })
@@ -60,18 +63,17 @@ public class CommonController {
   }
 
   @GetMapping("/userInfo/{username}")
-  @Operation(summary = "내 정보 조회", description = "내 정보 조회를 위한 api입니다.")
+  @Operation(summary = "내 정보 조회 (구현 완료)", description = "내 정보 조회를 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "내 정보를 가져오는데 성공했습니다."),
       @ApiResponse(responseCode = "5xx", description = "내 정보를 가져오는데 실패했습니다.")
   })
   public UserInfoDto userInfo(@PathVariable String username) {
-    System.out.println("컨트롤러 진입");
     return userInfoService.getUserInfoByUserName(username);
   }
 
   @GetMapping("/logout")
-  @Operation(summary = "로그아웃", description = "로그아웃을 위한 api입니다.")
+  @Operation(summary = "로그아웃 (미구현)", description = "로그아웃을 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "로그아웃에 성공했습니다."),
       @ApiResponse(responseCode = "5xx", description = "로그아웃에 실패했습니다.")
@@ -81,33 +83,33 @@ public class CommonController {
   }
 
   @DeleteMapping("/withdraw")
-  @Operation(summary = "회원탈퇴", description = "회원탈퇴를 위한 api입니다.")
+  @Operation(summary = "회원탈퇴 (구현 완료)", description = "회원탈퇴를 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "회원탈퇴에 성공했습니다."),
       @ApiResponse(responseCode = "5xx", description = "회원탈퇴에 실패했습니다.")
   })
-  public void withdrawService() {
-
+  public void withdrawService(Authentication authentication) {
+    myPageService.withDrawUser(authentication);
   }
 
   @PutMapping("/profileImg")
-  @Operation(summary = "프로필 이미지수정", description = "프로필 이미지 수정을 위한 api입니다.")
+  @Operation(summary = "프로필 이미지수정 (구현 완료)", description = "프로필 이미지 수정을 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "프로필 이미지 수정에 성공했습니다."),
       @ApiResponse(responseCode = "5xx", description = "프로필 이미지 수정에 실패했습니다.")
   })
-  public void modifyImg() {
-
+  public void modifyImg(Authentication authentication, @RequestParam String newProfileImgUrl ) {
+    myPageService.modifyProfileImg(authentication, newProfileImgUrl);
   }
 
   @DeleteMapping("/profileImg")
-  @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지 삭제를 위한 api입니다.")
+  @Operation(summary = "프로필 이미지 삭제 (구현 완료)", description = "프로필 이미지 삭제를 위한 api입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "프로필 이미지 삭제에 성공했습니다."),
       @ApiResponse(responseCode = "5xx", description = "프로필 이미지 삭제에 실패했습니다.")
   })
-  public void deleteImg() {
-
+  public void deleteImg(Authentication authentication) {
+    myPageService.deleteProfileImg(authentication);
   }
 
 

--- a/src/main/java/gitbal/backend/controller/MyPageController.java
+++ b/src/main/java/gitbal/backend/controller/MyPageController.java
@@ -1,22 +1,30 @@
 package gitbal.backend.controller;
 
+import gitbal.backend.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/my")
-@Tag(name = "마이페이지 API(미구현)", description = "마이페이지에 필요한 정보를 위한 api입니다.")
+@RequiredArgsConstructor
+@Tag(name = "마이페이지 API(일부 구현)", description = "마이페이지에 필요한 정보를 위한 api입니다.")
 public class MyPageController {
+
+    private final MyPageService myPageService;
 
 
     @GetMapping("/title/list")
-    @Operation(summary = "현재 가지고 있는 칭호", description = "현재 가지고 있는 칭호를 긁어오는 api 입니다.")
+    @Operation(summary = "현재 가지고 있는 칭호 (칭호 기획 이후 구현 예정)", description = "현재 가지고 있는 칭호를 긁어오는 api 입니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "칭호를 가져오는데 성공했습니다."),
         @ApiResponse(responseCode = "5xx", description = "칭호를 가져오는데 실패했습니다.")
@@ -27,24 +35,25 @@ public class MyPageController {
 
 
     @PutMapping("/config/school")
-    @Operation(summary = "학교 수정", description = "학교 수정을 위한 api입니다.")
+    @Operation(summary = "학교 수정 (구현 완료)", description = "학교 수정을 위한 api입니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "학교 수정에 성공했습니다."),
         @ApiResponse(responseCode = "5xx", description = "학교 수정에 실패했습니다.")
     })
-    public void modifySchool(){
-
+    public void modifySchool(Authentication authentication, @RequestParam String modifySchoolName){
+        myPageService.modifySchoolName(authentication, modifySchoolName);
     }
 
     @PutMapping("/config/region")
-    @Operation(summary = "지역 수정", description = "지역 수정을 위한 api입니다.")
+    @Operation(summary = "지역 수정 (구현 완료)", description = "지역 수정을 위한 api입니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "지역 수정에 성공했습니다."),
         @ApiResponse(responseCode = "5xx", description = "지역 수정에 실패했습니다.")
     })
-    public void modifyRegion(){
-
+    public void modifyRegion(Authentication authentication, @RequestParam String modifyRegionName){
+        myPageService.modifyRegionName(authentication, modifyRegionName);
     }
+
 
 
 

--- a/src/main/java/gitbal/backend/controller/UnivController.java
+++ b/src/main/java/gitbal/backend/controller/UnivController.java
@@ -26,7 +26,7 @@ public class UnivController {
 
 
   @PostMapping("/certificate")
-  @Operation(summary = "대학 인증 메일을 요청.", description = "대학 인증을 위해 요청하는 곳입니다.")
+  @Operation(summary = "대학 인증 메일을 요청 (구현 완료)", description = "대학 인증을 위해 요청하는 곳입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "대학 인증 요청을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "대학 인증 요청을 실패했습니다.")
@@ -38,7 +38,7 @@ public class UnivController {
 
 
   @PostMapping("/validate")
-  @Operation(summary = "메일로 받은 인증번호 검증", description = "메일로 받은 인증번호를 검증하는 곳입니다.")
+  @Operation(summary = "메일로 받은 인증번호 검증 (구현완료)", description = "메일로 받은 인증번호를 검증하는 곳입니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "인증번호 검증을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "인증번호 검증을 실패했습니다.")

--- a/src/main/java/gitbal/backend/entity/User.java
+++ b/src/main/java/gitbal/backend/entity/User.java
@@ -44,11 +44,11 @@ public class User {
     @JoinColumn(name = "region_id")
     private Region region;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "commit_date_id")
     private OneDayCommit oneDayCommit;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinColumn(name = "major_user_id")
     private List<MajorLanguage> majorLanguages = new ArrayList<>();
 
@@ -65,6 +65,18 @@ public class User {
     // 등급 관련 설정
     @Enumerated(value = EnumType.STRING)
     private Grade grade;
+
+    public void setSchool(School school) {
+        this.school = school;
+    }
+
+    public void setRegion(Region region) {
+        this.region = region;
+    }
+
+    public void setProfileImg(String profile_img) {
+        this.profile_img = profile_img;
+    }
 
     @Builder
     public User(School school, Region region, OneDayCommit oneDayCommit,

--- a/src/main/java/gitbal/backend/mock/MockDataGenerator.java
+++ b/src/main/java/gitbal/backend/mock/MockDataGenerator.java
@@ -74,6 +74,10 @@ public class MockDataGenerator implements CommandLineRunner {
 
 
     }
+    // Test를 위한 나(이승준)의 githubid와 동일한 nickname data
+    createUserWithNickname("leesj000603");
+
+
     insertRegionSchoolTopContributorInfo();
     log.info("Mock data creation completed");
   }
@@ -92,6 +96,34 @@ public class MockDataGenerator implements CommandLineRunner {
         .profile_img(randomProfileImg)
         .grade(Grade.NEWBIE)
         .build();
+  }
+
+  private void createUserWithNickname(String nickName) {
+    School school = schoolRepository.findById(1L)
+        .orElse(null);
+    Region region = regionRepository.findById(1L)
+        .orElse(null);
+    OneDayCommit oneDayCommit = OneDayCommit.of(true);
+    oneDayCommitRepository.save(oneDayCommit);
+
+    User leesj000603 = User.builder()
+        .school(school)
+        .region(region)
+        .nickname(nickName)
+        .score(500L)
+        .profile_img("sdqsdqwefqwef")
+        .grade(Grade.PURPLE)
+        .build();
+
+    List<MajorLanguage> majorLanguages = createRandomMajorLanguagesForUser(leesj000603);
+    majorLanguages.forEach(majorLanguageRepository::save);
+
+    OneDayCommit oneDayCommit1 = OneDayCommit.of(true);
+    oneDayCommitRepository.save(oneDayCommit1);
+    leesj000603.joinUpdateUser(school, region, oneDayCommit, majorLanguages,
+        leesj000603.getNickname(), leesj000603.getScore(), leesj000603.getProfile_img(), Grade.NEWBIE);
+    userRepository.save(leesj000603);
+
   }
 
   private List<MajorLanguage> createRandomMajorLanguagesForUser(User user) {

--- a/src/main/java/gitbal/backend/service/MyPageService.java
+++ b/src/main/java/gitbal/backend/service/MyPageService.java
@@ -1,0 +1,108 @@
+package gitbal.backend.service;
+
+import ch.qos.logback.core.net.SyslogOutputStream;
+import gitbal.backend.entity.Region;
+import gitbal.backend.entity.School;
+import gitbal.backend.entity.User;
+import gitbal.backend.exception.NotLoginedException;
+import gitbal.backend.repository.RegionRepository;
+import gitbal.backend.repository.SchoolRepository;
+import gitbal.backend.repository.UserRepository;
+import gitbal.backend.security.CustomUserDetails;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+  private final UserRepository userRepository;
+  private final SchoolRepository schoolRepository;
+  private final RegionRepository regionRepository;
+
+  //지역이나 학교 수정해도 수정하기 전 후의 지역점수나 학교점수에 유저 점수 직접 더하고 빼지 않음. (어짜피 점수 업데이트 할 때 반영되니깐)
+
+  public void modifySchoolName(Authentication authentication, String newSchoolName) {
+    if (authentication == null){
+      throw new NotLoginedException();
+    }
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    String username = principal.getNickname();
+    User user = null;
+    School newSchool = null;
+    try {
+      user = userRepository.findByNickname(username).get();
+      newSchool = schoolRepository.findBySchoolName(newSchoolName).get();
+    } catch (NullPointerException e) {
+      // Exception 처리
+    }
+    user.setSchool(newSchool);
+    userRepository.save(user);
+  }
+
+  public void modifyRegionName(Authentication authentication, String newRegionName){
+    if (authentication == null){
+      throw new NotLoginedException();
+    }
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    String username = principal.getNickname();
+
+    User user = null;
+    Region newRegion = null;
+    try {
+      user = userRepository.findByNickname(username).get();
+      newRegion = regionRepository.findByRegionName(newRegionName).get();
+    } catch (NullPointerException e) {
+      // Exception 처리
+    }
+    user.setRegion(newRegion);
+    userRepository.save(user); // save가 아닌 다른 방식 찾아야함
+  }
+
+  public void modifyProfileImg (Authentication authentication, String newProfileImgUrl) {
+    if (authentication == null){
+      throw new NotLoginedException();
+    }
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    String username = principal.getNickname();
+
+    User user = null;
+    try {
+      user = userRepository.findByNickname(username).get();
+    } catch (NullPointerException e) {
+      // Exception 처리
+    }
+    user.setProfileImg(newProfileImgUrl);
+    userRepository.save(user);
+  }
+
+  public void deleteProfileImg (Authentication authentication) {
+    if (authentication == null){
+      throw new NotLoginedException();
+    }
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    String username = principal.getNickname();
+
+    User user = null;
+    try {
+      user = userRepository.findByNickname(username).get();
+    } catch (NullPointerException e) {
+      // Exception 처리
+    }
+    user.setProfileImg(null);
+    userRepository.save(user);
+  }
+
+  public void withDrawUser (Authentication authentication) {
+    if (authentication == null){
+      throw new NotLoginedException();
+    }
+    CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+    String username = principal.getNickname();
+
+    Optional<User> user = null;
+    user = userRepository.findByNickname(username);
+    userRepository.delete(user.get());
+  }
+}

--- a/src/main/java/gitbal/backend/service/UserInfoService.java
+++ b/src/main/java/gitbal/backend/service/UserInfoService.java
@@ -21,8 +21,7 @@ public class UserInfoService {
   private final RegionRepository regionRepository;
   private final SchoolRepository schoolRepository;
 
-  public UserInfoDto getUserInfoByUserName(String userName) { // Todo: 현재 컨트롤러로 보내는 과정에서 문제 있음.
-    System.out.println("서비스 진입");
+  public UserInfoDto getUserInfoByUserName(String userName) {
     Optional<User> result = userRepository.findByNickname(userName);
 
     if (result.isPresent()) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#76 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
api/v1/config/school , api/v1/config/region, api/v1/profileImg, api/v1/withdraw 개발


### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)
1. api/v1/config/school
 수정 전
 
![학교, 지역 수정전](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/c7a81e27-df35-4b74-bc93-b971ff1edd82)


수정 후
![학교 수정후](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/29483f08-7450-4bb7-acd8-e60ac224aa1d)


2.  api/v1/config/region
변경 전
![지역 변경 전](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/3a931d2f-a87a-477b-8aa0-be93e3769407)

변경 후
![지역 변경 후](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/e2a51a51-5abf-4196-abbd-2ed18998015f)

3.api/v1/profileImg
수정
![캡처(2)](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/f3c69b1c-bd6a-4866-85db-50825c787219)

삭제
![캡처3](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/ab29345e-0841-48f9-91a5-b80e8de84c20)

4. api/v1/withdraw
삭제 후
![유저 삭제](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/d62aea0c-c667-488d-a8e3-e2041a5f8ab3)

userEntity cascade delete 옵션 추가 했으므로 삭제 시 다른 테이블에서 user를 참조하는 튜플 삭제
삭제 전 
![다른 테이블 유저 삭제 점](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/cf96fc79-f191-451e-9948-17a32d6284c2)

삭제 후
![다른 곳 유저 삭제](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/6a23496e-e3ec-4e3c-b1bf-c31ceb054e61)
 
## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..
