### PR TITLE
[feat] #97 /api/v1/auth/logout 구현

### DIFF
--- a/src/main/java/gitbal/backend/api/auth/controller/AuthController.java
+++ b/src/main/java/gitbal/backend/api/auth/controller/AuthController.java
@@ -48,6 +48,7 @@ public class AuthController {
 
 
 
+    //TODO : 리팩토링 과정에서 Authentication 으로 처리하도록 하기
     @GetMapping("/userInfo/{username}")
     @Operation(summary = "유저 정보 조회 (구현 완료)", description = "유저 정보 조회를 위한 api입니다.")
     @ApiResponses(value = {
@@ -56,17 +57,6 @@ public class AuthController {
     })
     public ResponseEntity<UserInfoDto> userInfo(@PathVariable String username) {
         return userInfoService.getUserInfoByUserName(username);
-    }
-
-
-    @GetMapping("/logout")
-    @Operation(summary = "로그아웃 (미구현)", description = "로그아웃을 위한 api입니다.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "로그아웃에 성공했습니다."),
-        @ApiResponse(responseCode = "5xx", description = "로그아웃에 실패했습니다.")
-    })
-    public void logout() {
-
     }
 
 

--- a/src/main/java/gitbal/backend/api/auth/service/AuthService.java
+++ b/src/main/java/gitbal/backend/api/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package gitbal.backend.api.auth.service;
 
 import gitbal.backend.api.auth.dto.JoinRequestDto;
 import gitbal.backend.api.auth.dto.UserDto;
+import gitbal.backend.domain.refreshtoken.RefreshTokenService;
 import gitbal.backend.global.constant.Grade;
 import gitbal.backend.domain.user.User;
 import gitbal.backend.domain.user.UserRepository;
@@ -11,13 +12,12 @@ import gitbal.backend.domain.region.RegionService;
 import gitbal.backend.domain.school.SchoolService;
 import gitbal.backend.domain.user.UserService;
 import gitbal.backend.global.exception.JoinException;
+import gitbal.backend.global.exception.LogoutException;
 import gitbal.backend.global.exception.NotDrawUserException;
 import gitbal.backend.global.exception.NotFoundUserException;
 import gitbal.backend.global.security.CustomUserDetails;
-import gitbal.backend.global.security.jwt.JwtTokenProvider;
 import gitbal.backend.global.util.AuthenticationChecker;
 import gitbal.backend.api.auth.dto.GitbalApiDto;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -35,6 +35,7 @@ public class AuthService {
     private final UserService userService;
     private final UserRepository userRepository;
     private final AuthenticationChecker authenticationChecker;
+    private final RefreshTokenService refreshTokenService;
 
 
     //TODO: 회원가입을 위한 -> 학교, 지역, 주언어, 커밋 날짜를 넣어야함!
@@ -104,4 +105,14 @@ public class AuthService {
     }
 
 
+    @Transactional
+    public String logoutUser(String username) {
+        try {
+            refreshTokenService.deleteByUsername(username);
+            return "로그아웃에 성공하였습니다.";
+        }catch (Exception e){
+            e.printStackTrace();
+            throw new LogoutException("로그아웃 실패");
+        }
+    }
 }

--- a/src/main/java/gitbal/backend/domain/refreshtoken/RefreshTokenRepository.java
+++ b/src/main/java/gitbal/backend/domain/refreshtoken/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByUserNickname(String userNickname);
 
+    void deleteByUserNickname(String userNickname);
+
 }

--- a/src/main/java/gitbal/backend/domain/refreshtoken/RefreshTokenService.java
+++ b/src/main/java/gitbal/backend/domain/refreshtoken/RefreshTokenService.java
@@ -1,0 +1,23 @@
+package gitbal.backend.domain.refreshtoken;
+
+import gitbal.backend.global.exception.NotFoundRefreshTokenException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+    public void deleteByUsername(String username){
+        RefreshToken refreshToken = refreshTokenRepository.findByUserNickname(username).orElseThrow(
+            NotFoundRefreshTokenException::new);
+        refreshTokenRepository.deleteById(refreshToken.getRefreshToken());
+    }
+
+
+}

--- a/src/main/java/gitbal/backend/global/config/SecurityConfig.java
+++ b/src/main/java/gitbal/backend/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package gitbal.backend.global.config;
 
+import gitbal.backend.global.security.CustomLogoutHandler;
+import gitbal.backend.global.security.CustomLogoutSuccessHandler;
 import gitbal.backend.global.security.CustomOAuth2UserService;
 import gitbal.backend.global.security.OAuth2AuthenticationSuccessHandler;
 import gitbal.backend.global.security.jwt.JwtAuthenticationFilter;
@@ -23,6 +25,8 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomLogoutHandler customLogoutHandler;
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,11 +38,17 @@ public class SecurityConfig {
                     auth.requestMatchers("/swagger-ui/**", "/").permitAll();
                     auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                         .permitAll();
-                    auth.requestMatchers("/api/v1/login", "/api/v1/join", "/api/v1/schoolRank/mySchool") // TODO : 로그인 필요한 uri 다 집어넣기
+                    auth.requestMatchers("/api/v1/auth/logout","/api/v1/login", "/api/v1/join", "/api/v1/schoolRank/mySchool") // TODO : 로그인 필요한 uri 다 집어넣기
                         .authenticated();
                     auth.anyRequest().permitAll();
                 }
             )
+            .logout(logout -> {
+                logout.logoutUrl("/api/v1/auth/logout");
+                logout.addLogoutHandler(customLogoutHandler);
+                logout.deleteCookies("JSESSIONID", "remember-me");
+                logout.logoutSuccessHandler(customLogoutSuccessHandler);
+            })
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(user -> user.userService(customOAuth2UserService));
                 oauth2.successHandler(oAuth2AuthenticationSuccessHandler);
@@ -48,6 +58,9 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
     }
+
+
+
 
 
     @Bean

--- a/src/main/java/gitbal/backend/global/exception/LogoutException.java
+++ b/src/main/java/gitbal/backend/global/exception/LogoutException.java
@@ -1,0 +1,11 @@
+package gitbal.backend.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class LogoutException extends RuntimeException{
+
+    public LogoutException() {
+        super("로그아웃에 실패하였습니다.");
+    }
+}

--- a/src/main/java/gitbal/backend/global/exception/NoTokenException.java
+++ b/src/main/java/gitbal/backend/global/exception/NoTokenException.java
@@ -1,2 +1,11 @@
-package gitbal.backend.global.exception;public class NoTokenException {
+package gitbal.backend.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class NoTokenException extends RuntimeException{
+
+    public NoTokenException() {
+        super("토큰이 존재하지 않습니다.");
+    }
 }

--- a/src/main/java/gitbal/backend/global/exception/NoTokenException.java
+++ b/src/main/java/gitbal/backend/global/exception/NoTokenException.java
@@ -1,0 +1,2 @@
+package gitbal.backend.global.exception;public class NoTokenException {
+}

--- a/src/main/java/gitbal/backend/global/exception/NotFoundRefreshTokenException.java
+++ b/src/main/java/gitbal/backend/global/exception/NotFoundRefreshTokenException.java
@@ -1,0 +1,11 @@
+package gitbal.backend.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class NotFoundRefreshTokenException extends RuntimeException{
+
+    public NotFoundRefreshTokenException() {
+        super("refereshToken을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/gitbal/backend/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gitbal/backend/global/handler/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package gitbal.backend.global.handler;
 
 import gitbal.backend.global.exception.JoinException;
+import gitbal.backend.global.exception.LogoutException;
 import gitbal.backend.global.exception.MainPageFirstRankException;
+import gitbal.backend.global.exception.NoTokenException;
 import gitbal.backend.global.exception.NotDrawUserException;
+import gitbal.backend.global.exception.NotFoundRefreshTokenException;
 import gitbal.backend.global.exception.NotFoundRegionException;
 import gitbal.backend.global.exception.NotFoundSchoolException;
 import gitbal.backend.global.exception.NotFoundUserException;
@@ -67,6 +70,23 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotDrawUserException.class)
     public  ResponseEntity<String> handleDrawUserException(NotDrawUserException e){
         return ResponseEntity.status(500).body(e.getMessage());
+    }
+
+
+    @ExceptionHandler(LogoutException.class)
+    public  ResponseEntity<String> handleLogoutException(LogoutException e){
+        return ResponseEntity.status(400).body(e.getMessage());
+    }
+
+    @ExceptionHandler(NotFoundRefreshTokenException.class)
+    public  ResponseEntity<String> handleRefreshTokenException(NotFoundRefreshTokenException e){
+        return ResponseEntity.status(400).body(e.getMessage());
+    }
+
+
+    @ExceptionHandler(NoTokenException.class)
+    public  ResponseEntity<String> handleNoTokenException(NoTokenException e){
+        return ResponseEntity.status(400).body(e.getMessage());
     }
 
 }

--- a/src/main/java/gitbal/backend/global/security/CustomLogoutHandler.java
+++ b/src/main/java/gitbal/backend/global/security/CustomLogoutHandler.java
@@ -1,0 +1,38 @@
+package gitbal.backend.global.security;
+
+import gitbal.backend.api.auth.service.AuthService;
+import gitbal.backend.global.exception.LogoutException;
+import gitbal.backend.global.security.jwt.JwtUtils;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomLogoutHandler implements LogoutHandler {
+
+    @Value("${jwt.key}")
+    private String jwtKey;
+    private final AuthService authService;
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) {
+        try {
+            String bearerToken = request.getHeader("Authorization");
+            String bearer = bearerToken.split("Bearer ")[1];
+            log.info(bearer);
+            Claims claims = JwtUtils.parseClaims(bearer, jwtKey);
+            authService.logoutUser(claims.getSubject());
+        }catch (Exception e){
+            e.printStackTrace();
+            throw new LogoutException();
+        }
+    }
+}

--- a/src/main/java/gitbal/backend/global/security/CustomLogoutHandler.java
+++ b/src/main/java/gitbal/backend/global/security/CustomLogoutHandler.java
@@ -24,15 +24,9 @@ public class CustomLogoutHandler implements LogoutHandler {
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) {
-        try {
-            String bearerToken = request.getHeader("Authorization");
-            String bearer = bearerToken.split("Bearer ")[1];
-            log.info(bearer);
-            Claims claims = JwtUtils.parseClaims(bearer, jwtKey);
-            authService.logoutUser(claims.getSubject());
-        }catch (Exception e){
-            e.printStackTrace();
-            throw new LogoutException();
-        }
+        String bearer = JwtUtils.extractBearerToken(request);
+        log.info(bearer);
+        Claims claims = JwtUtils.parseClaims(bearer, jwtKey);
+        authService.logoutUser(claims.getSubject());
     }
 }

--- a/src/main/java/gitbal/backend/global/security/CustomLogoutSuccessHandler.java
+++ b/src/main/java/gitbal/backend/global/security/CustomLogoutSuccessHandler.java
@@ -1,0 +1,22 @@
+package gitbal.backend.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\": \"Logout successful\"}");
+    }
+}

--- a/src/main/java/gitbal/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/gitbal/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -22,8 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
     private final String AUTHORIZATION_HEADER = "Authorization";
-    private final String BEARER_PREFIX = "Bearer ";
-    private final String URL_PREFIX = "accessToken=";
+
 
 
     @Override
@@ -64,22 +63,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String extractAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         String urlToken = request.getQueryString();
-
-        return checkUrlOrBearerToken(bearerToken, urlToken);
-    }
-
-    private String checkUrlOrBearerToken(String bearerToken, String urlToken) {
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            String token = bearerToken.split(BEARER_PREFIX)[1];
-            log.info("[checkUrlOrBearerToken] header accessToken is =" + token);
-            return token;
-        }
-        if (StringUtils.hasText(urlToken) && urlToken.startsWith(URL_PREFIX)) {
-            String token = urlToken.split(URL_PREFIX)[1];
-            log.info("[checkUrlOrBearerToken] url Token is =" + token);
-            return token;
-        }
-        return null;
+        return JwtUtils.extractUrlOrBearerToken(bearerToken, urlToken);
     }
 
 

--- a/src/main/java/gitbal/backend/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/gitbal/backend/global/security/jwt/JwtTokenProvider.java
@@ -85,7 +85,7 @@ public class JwtTokenProvider {
         return regenerateToken;
     }
 
-    private String findUserNicknameByToken(String accessToken) {
+    public String findUserNicknameByToken(String accessToken) {
         return JwtUtils.parseClaims(accessToken, key).getSubject();
     }
 

--- a/src/main/java/gitbal/backend/global/security/jwt/JwtUtils.java
+++ b/src/main/java/gitbal/backend/global/security/jwt/JwtUtils.java
@@ -1,19 +1,26 @@
 package gitbal.backend.global.security.jwt;
 
+import gitbal.backend.global.exception.NoTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class JwtUtils {
+
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String URL_PREFIX = "accessToken=";
 
     public static Claims parseClaims(String accessToken, String key) {
         try {
@@ -39,4 +46,34 @@ public class JwtUtils {
     }
 
 
+    public static String extractBearerToken(HttpServletRequest request){
+        String tokenHeader = request.getHeader("Authorization");
+        if(StringUtils.hasText(tokenHeader)){
+            return extractBearerToken(tokenHeader);
+        }
+        throw new NoTokenException();
+    }
+
+    private static String extractBearerToken(String bearerToken) {
+        String token = bearerToken.split(BEARER_PREFIX)[1];
+        log.info("[extractBearerToken] header accessToken is =" + token);
+        return token;
+    }
+
+
+    private static String extractUrlToken(String urlToken) {
+        String token = urlToken.split(URL_PREFIX)[1];
+        log.info("[extractUrlToken] url Token is =" + token);
+        return token;
+    }
+
+    public static String extractUrlOrBearerToken(String bearerToken, String urlToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return extractBearerToken(bearerToken);
+        }
+        if (StringUtils.hasText(urlToken) && urlToken.startsWith(URL_PREFIX)) {
+            return extractUrlToken(urlToken);
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#97 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

logout 기능을 구현하였습니다.
중간에 진행하다가 따로 api 처리라기보다 Spring Security의 기능을 사용하여서 진행을 하였습니다.
security를 사용하였기에 post 메서드를 활용하여 요청을 보내야합니다.
추가적으로 공통으로 사용되는 로직에 대한 리팩토링을 수행하였습니다.

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)

### 실행 전
![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/38220795/3dec43fb-25ab-4c27-82c0-7e71a12eeec9)



### 실행 후
![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/38220795/103e2284-b4e9-43d6-a537-70f3b3226204)



refresh token 을 없애는 과정을 거칩니다. 이를 통해 fe 에서 로그아웃을 시킨 후 refreshToken을 무효화 시키는 과정을 거치게 됩니다.

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..


closes #97 
