### PR TITLE
[feat] #104 - school, user 등급 계산 후 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 
 
 <br>
-
 ## 팀원 구성
 
 <div align="center">

--- a/src/main/java/gitbal/backend/api/auth/service/AuthService.java
+++ b/src/main/java/gitbal/backend/api/auth/service/AuthService.java
@@ -89,7 +89,8 @@ public class AuthService {
             userDto.nickname(),
             userDto.score(),
             userDto.profile_img(),
-            Grade.NEWBIE //TODO : 일단 들어올 때 뉴비로 측정하기로 함! -> 이후에 기획 확정된 이후에 등급 계산 로직 넣고 수정해야함!
+            Grade.YELLOW, //TODO : 일단 들어올 때 최하 등급으로 측정하기로 함! -> 이후에 기획 확정된 이후에 등급 계산 로직 넣고 수정해야함!
+            0
         );
         schoolService.joinNewUserScore(findUser);
         regionService.joinNewUserScore(findUser);

--- a/src/main/java/gitbal/backend/domain/school/School.java
+++ b/src/main/java/gitbal/backend/domain/school/School.java
@@ -2,6 +2,8 @@ package gitbal.backend.domain.school;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import gitbal.backend.global.constant.SchoolGrade;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,6 +39,9 @@ public class School {
 
   @ColumnDefault(value = "0")
   private int schoolRank;
+
+  @Enumerated(value = EnumType.STRING)
+  private SchoolGrade grade;
 
   @NotNull
   private String topContributor;
@@ -65,6 +71,8 @@ public class School {
       this.contributorScore = score;
     }
   }
+
+  public void setGrade(SchoolGrade grade) { this.grade = grade; }
 
   public void setSchoolRank(int rank) {
     this.schoolRank=rank;

--- a/src/main/java/gitbal/backend/domain/user/User.java
+++ b/src/main/java/gitbal/backend/domain/user/User.java
@@ -70,6 +70,14 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private Grade grade;
 
+    @Column(name = "user_rank")
+    @ColumnDefault("0")
+    private Integer userRank;
+
+    public void setGrade(Grade grade) { this.grade = grade; }
+
+    public void setUserRank(Integer userRank) {this.userRank = userRank;}
+
     public void setSchool(School school) {
         this.school = school;
     }
@@ -85,7 +93,7 @@ public class User {
     @Builder
     public User(School school, Region region, OneDayCommit oneDayCommit,
         List<MajorLanguage> majorLanguages,
-        String nickname, Long score, String profile_img, Grade grade) {
+        String nickname, Long score, String profile_img, Grade grade,Integer userRank) {
         this.school = school;
         this.region = region;
         this.oneDayCommit = oneDayCommit;
@@ -94,12 +102,13 @@ public class User {
         this.score = score;
         this.profile_img = profile_img;
         this.grade = grade;
+        this.userRank = userRank;
     }
 
 
     public void joinUpdateUser(School school, Region region, OneDayCommit oneDayCommit,
         List<MajorLanguage> majorLanguages,
-        String nickname, Long score, String profile_img, Grade grade) {
+        String nickname, Long score, String profile_img, Grade grade, Integer userRank) {
         this.school = school;
         this.region = region;
         this.oneDayCommit = oneDayCommit;
@@ -107,10 +116,11 @@ public class User {
         this.nickname = nickname;
         this.score = score;
         this.profile_img = profile_img;
+        this.userRank = userRank;
     }
 
     public static User of(String username, String avatarUrl) {
-        return new User(null, null, null, null, username, 0L, avatarUrl, Grade.NEWBIE);
+        return new User(null, null, null, null, username, 0L, avatarUrl, Grade.YELLOW, 0);
     }
 
 

--- a/src/main/java/gitbal/backend/global/constant/Grade.java
+++ b/src/main/java/gitbal/backend/global/constant/Grade.java
@@ -1,5 +1,5 @@
 package gitbal.backend.global.constant;
 
 public enum Grade {
-    NEWBIE, GREEN, RED, PURPLE
+    YELLOW, GREEN, BLUE, RED, GREY, PURPLE
 }

--- a/src/main/java/gitbal/backend/global/constant/SchoolGrade.java
+++ b/src/main/java/gitbal/backend/global/constant/SchoolGrade.java
@@ -1,0 +1,5 @@
+package gitbal.backend.global.constant;
+
+public enum SchoolGrade {
+  YELLOW, GREEN, BLUE, RED, GREY, PURPLE
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#104

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
user 엔티티의 rank컬럼추가, school 엔티티의 grade컬럼 추가, SchoolGrade constant 추가
school 및 user의 등급을 mockDataGenerator에서 생성할때 각각 등급 계산 규칙에 맞게 계산하여 적용

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)
![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/efe81e2a-c10a-45fe-bca3-a8ceef38d90c)

![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/c9458685-c540-4cca-a5d4-abeff34bedbe)

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..
