### PR TITLE
[fix] #121 - fe요청에 따른 검색시에 유저나 학교가 아무것도 없을 경우 빈 리스트로 전달, search api를 해당 컨트롤러의 list 불러오는 api에 통합

### DIFF
--- a/src/main/java/gitbal/backend/api/mainPage/controller/MainPageController.java
+++ b/src/main/java/gitbal/backend/api/mainPage/controller/MainPageController.java
@@ -28,8 +28,8 @@ public class MainPageController {
         @ApiResponse(responseCode = "200", description = "유저들을 가져오는데 성공했습니다."),
         @ApiResponse(responseCode = "400", description = "유저들을 가져오는데 실패했습니다.")
     })
-    public ResponseEntity<MainPageUserResponseDto> users(@RequestParam int page) {
-        return ResponseEntity.ok(mainPageService.getUsers(page));
+    public ResponseEntity<MainPageUserResponseDto> users(@RequestParam(required = false, defaultValue = "1") int page,  @RequestParam(required = false) String searchedname) {
+        return ResponseEntity.ok(mainPageService.getUsers(page, searchedname));
     }
 
 
@@ -43,15 +43,6 @@ public class MainPageController {
         return ResponseEntity.ok(mainPageService.getMainPageFirstSchoolRegionRank());
     }
 
-    @GetMapping("/search")
-    @Operation(summary = "메인 페이지 검색한 유저를 나오게 하는 API입니다.(일부 구현 완료 -> 등급 기획 완성시 다시 개발 진행)", description = "메인 검색 유저 관련 api 12명씩 대소문자 구분없이 검색.")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "유저이름 검색에 성공했습니다."),
-        @ApiResponse(responseCode = "400", description = "유저이름 검색에 실패했습니다.")
-    })
-    public ResponseEntity<MainPageUserResponseDto> search(@RequestParam String searchedname, @RequestParam(required = false, defaultValue = "0") int page) {
-        return ResponseEntity.ok(mainPageService.getSearchedUserList(searchedname, page));
-    }
 
 
 }

--- a/src/main/java/gitbal/backend/api/mainPage/service/MainPageService.java
+++ b/src/main/java/gitbal/backend/api/mainPage/service/MainPageService.java
@@ -1,21 +1,20 @@
 package gitbal.backend.api.mainPage.service;
 
-import gitbal.backend.global.dto.PageInfoDto;
-import gitbal.backend.domain.region.Region;
-import gitbal.backend.domain.school.School;
 import gitbal.backend.api.mainPage.dto.MainPageFirstRankResponseDto;
 import gitbal.backend.api.mainPage.dto.MainPageUserDto;
-import gitbal.backend.domain.user.User;
 import gitbal.backend.api.mainPage.dto.MainPageUserResponseDto;
-import gitbal.backend.global.util.PageCalculator;
-
-import gitbal.backend.global.exception.MainPageFirstRankException;
-import gitbal.backend.global.exception.NotFoundUserException;
-import gitbal.backend.global.exception.WrongPageNumberException;
+import gitbal.backend.domain.region.Region;
 import gitbal.backend.domain.region.RegionRepository;
+import gitbal.backend.domain.school.School;
 import gitbal.backend.domain.school.SchoolRepository;
+import gitbal.backend.domain.user.User;
 import gitbal.backend.domain.user.UserRepository;
+import gitbal.backend.global.dto.PageInfoDto;
+import gitbal.backend.global.exception.MainPageFirstRankException;
+import gitbal.backend.global.exception.WrongPageNumberException;
+import gitbal.backend.global.util.PageCalculator;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -36,14 +35,16 @@ public class MainPageService {
 
 
     @Transactional(readOnly = true)
-    public MainPageUserResponseDto getUsers(int page) {
+    public MainPageUserResponseDto getUsers(int page, String searchedname) {
+        if (!Objects.isNull(searchedname))   return getSearchedUserList(searchedname, page);
         try {
             Page<User> users = userRepository.findAll(
                 PageRequest.of(page - 1, PAGE_SIZE, Sort.by("score").descending()));
             validatePage(page, users.getTotalElements());
             log.info(String.valueOf(users.getTotalElements()));
             List<MainPageUserDto> userList = users.stream().map(
-                    (user) -> new MainPageUserDto(user.getNickname(), user.getScore(), user.getUserRank(), user.getGrade()))
+                    (user) -> new MainPageUserDto(user.getNickname(), user.getScore(),
+                        user.getUserRank(), user.getGrade()))
                 .toList();
             PageInfoDto pageInfoDto = PageCalculator.calculatePageInfo(users);
             return MainPageUserResponseDto.of(userList, pageInfoDto);
@@ -53,29 +54,28 @@ public class MainPageService {
         }
     }
 
-    public MainPageUserResponseDto getSearchedUserList(String searchedname, int page) {
-        if(page == 0){
-            page=1;
-        }try {
-            Page<User> searchUsersIgnoreCase = userRepository.findByNicknameContainingIgnoreCase(searchedname,
+    private MainPageUserResponseDto getSearchedUserList(String searchedname, int page) {
+        try {
+            Page<User> searchUsersIgnoreCase = userRepository.findByNicknameContainingIgnoreCase(
+                searchedname,
                 PageRequest.of(page - 1, PAGE_SIZE, Sort.by("score").descending()));
-            validateSearchUsername(searchUsersIgnoreCase);
+            if(isSearchedUserNone(searchUsersIgnoreCase))
+                return MainPageUserResponseDto.of(List.of(), new PageInfoDto(0, 0, 0, 0));
             validatePage(page, searchUsersIgnoreCase.getTotalElements());
             List<MainPageUserDto> searchUserList = searchUsersIgnoreCase.stream().map(
-                (user) -> new MainPageUserDto(user.getNickname(), user.getScore(), user.getUserRank(), user.getGrade())
+                (user) -> new MainPageUserDto(user.getNickname(), user.getScore(),
+                    user.getUserRank(), user.getGrade())
             ).toList();
             PageInfoDto pageInfoDto = PageCalculator.calculatePageInfo(searchUsersIgnoreCase);
             return MainPageUserResponseDto.of(searchUserList, pageInfoDto);
-        }catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             e.printStackTrace();
             throw new WrongPageNumberException(page);
         }
     }
 
-    private void validateSearchUsername(Page<User> searchUsersIgnoreCase) {
-        if(searchUsersIgnoreCase.getTotalElements()==0){
-            throw new NotFoundUserException();
-        }
+    private boolean isSearchedUserNone(Page<User> searchUsersIgnoreCase) {
+        return searchUsersIgnoreCase.getTotalElements() == 0;
     }
 
 
@@ -103,8 +103,8 @@ public class MainPageService {
         try {
             Region region = regionRepository.firstRankedRegion();
             School school = schoolRepository.firstRankedSchool();
-            return MainPageFirstRankResponseDto.of(school,region);
-        }catch (Exception e){
+            return MainPageFirstRankResponseDto.of(school, region);
+        } catch (Exception e) {
             e.printStackTrace();
             throw new MainPageFirstRankException();
         }

--- a/src/main/java/gitbal/backend/api/schoolPage/controller/SchoolRankController.java
+++ b/src/main/java/gitbal/backend/api/schoolPage/controller/SchoolRankController.java
@@ -53,20 +53,9 @@ public class SchoolRankController {
         @ApiResponse(responseCode = "200", description = "학교 리스트 요청을 성공했습니다."),
         @ApiResponse(responseCode = "5xx", description = "학교 리스트 요청을 실패했습니다.")
     })
-    public ResponseEntity<SchoolListPageResponseDto<SchoolListDto>> schoolList(@RequestParam int page) {
-        return schoolRankService.getSchoolList(page);
+    public ResponseEntity<SchoolListPageResponseDto<SchoolListDto>> schoolList(@RequestParam(defaultValue = "1", required = false) int page, @RequestParam(required = false) String searchedSchoolName) {
+        return ResponseEntity.ok(schoolRankService.getSchoolList(page, searchedSchoolName));
     }
 
-
-
-    @GetMapping("/search")
-    @Operation(summary = "학교 페이지에서 검색한 학교를 나오게 하는 API입니다.(일부 구현 완료 -> 등급 기획 완성시 다시 개발 진행)", description = "학교 검색시 api 10개씩 검색(영어는 대소문자 구분 안함).")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "학교이름 검색에 성공했습니다."),
-        @ApiResponse(responseCode = "400", description = "학교이름 검색에 실패했습니다.")
-    })
-    public ResponseEntity<SchoolListPageResponseDto<SchoolListDto>> searchSchoolList(@RequestParam String searchedSchoolName, @RequestParam(required = false, defaultValue = "0") int page){
-        return ResponseEntity.ok(schoolRankService.getSearchedSchoolList(searchedSchoolName, page));
-    }
 
 }

--- a/src/main/java/gitbal/backend/api/schoolPage/dto/SchoolListPageResponseDto.java
+++ b/src/main/java/gitbal/backend/api/schoolPage/dto/SchoolListPageResponseDto.java
@@ -1,5 +1,6 @@
 package gitbal.backend.api.schoolPage.dto;
 
+import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +22,13 @@ public class SchoolListPageResponseDto<E> {
     this.currentPage = page;
     int totalCount = total.intValue();
 
+    if(emptyPage(page)){
+        this.totalPages = 0;
+        this.start = 0;
+        this.end = 0;
+        return;
+    }
+
     int pageSize = 10;
     this.totalPages = (int) Math.ceil((double) totalCount / pageSize);
 
@@ -36,5 +44,17 @@ public class SchoolListPageResponseDto<E> {
       start = 0;
       end = 0;
     }
+  }
+
+  private static boolean emptyPage(int page) {
+    return page == 0;
+  }
+
+  public static SchoolListPageResponseDto<SchoolListDto> emptyList() {
+    return SchoolListPageResponseDto.<SchoolListDto>withALl()
+        .schoolList(Collections.emptyList())
+        .page(0)
+        .total(0L)
+        .build();
   }
 }


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#121 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

mainPage/users

![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/38220795/139d7792-9e0a-4c77-b5eb-c4381d7fa92e)

schoolRank/schoolList

![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/38220795/7c7dd72c-0875-46ed-bac0-059706de4a30)

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..
