### PR TITLE
Feature/#120 scheduling ranking update

### DIFF
--- a/src/main/java/gitbal/backend/api/univcert/controller/UnivController.java
+++ b/src/main/java/gitbal/backend/api/univcert/controller/UnivController.java
@@ -2,6 +2,7 @@ package gitbal.backend.api.univcert.controller;
 
 
 import gitbal.backend.api.univcert.dto.UnivCertCodeDto;
+import gitbal.backend.api.univcert.dto.UnivCertResponseDto;
 import gitbal.backend.api.univcert.dto.UnivCertStartDto;
 import gitbal.backend.api.univcert.service.UnivService;
 import gitbal.backend.global.exception.UnivCertCodeException;
@@ -34,8 +35,8 @@ public class UnivController {
       @ApiResponse(responseCode = "200", description = "대학 인증 요청을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "대학 인증 요청을 실패했습니다.")
   })
-  public ResponseEntity<Map<String, Object>> univRequestCertificate(@RequestBody UnivCertStartDto univCertStartDto) {
-    return ResponseEntity.ok(univSerivce.CertStart(univCertStartDto));
+  public ResponseEntity<UnivCertResponseDto> univRequestCertificate(@RequestBody UnivCertStartDto univCertStartDto) {
+    return ResponseEntity.ok(univSerivce.certStart(univCertStartDto));
   }
 
 
@@ -45,8 +46,8 @@ public class UnivController {
       @ApiResponse(responseCode = "200", description = "인증번호 검증을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "인증번호 검증을 실패했습니다.")
   })
-  public ResponseEntity<Map<String, Object>> univCertNumValidate(@RequestBody UnivCertCodeDto univCertCodeDto) {
-    return ResponseEntity.ok(univSerivce.CertCode(univCertCodeDto));
+  public ResponseEntity<UnivCertResponseDto> univCertNumValidate(@RequestBody UnivCertCodeDto univCertCodeDto) {
+    return ResponseEntity.ok(univSerivce.certCode(univCertCodeDto));
   }
 
 }

--- a/src/main/java/gitbal/backend/api/univcert/controller/UnivController.java
+++ b/src/main/java/gitbal/backend/api/univcert/controller/UnivController.java
@@ -4,11 +4,12 @@ package gitbal.backend.api.univcert.controller;
 import gitbal.backend.api.univcert.dto.UnivCertCodeDto;
 import gitbal.backend.api.univcert.dto.UnivCertStartDto;
 import gitbal.backend.api.univcert.service.UnivService;
+import gitbal.backend.global.exception.UnivCertCodeException;
+import gitbal.backend.global.exception.UnivCertStartException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,8 +34,7 @@ public class UnivController {
       @ApiResponse(responseCode = "200", description = "대학 인증 요청을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "대학 인증 요청을 실패했습니다.")
   })
-  public ResponseEntity<Map<String, Object>> univRequestCertificate(@RequestBody UnivCertStartDto univCertStartDto)
-      throws IOException {
+  public ResponseEntity<Map<String, Object>> univRequestCertificate(@RequestBody UnivCertStartDto univCertStartDto) {
     return ResponseEntity.ok(univSerivce.CertStart(univCertStartDto));
   }
 
@@ -45,11 +45,9 @@ public class UnivController {
       @ApiResponse(responseCode = "200", description = "인증번호 검증을 성공했습니다."),
       @ApiResponse(responseCode = "400", description = "인증번호 검증을 실패했습니다.")
   })
-  public ResponseEntity<Map<String, Object>> univCertNumValidate(@RequestBody UnivCertCodeDto univCertCodeDto)
-      throws IOException {
+  public ResponseEntity<Map<String, Object>> univCertNumValidate(@RequestBody UnivCertCodeDto univCertCodeDto) {
     return ResponseEntity.ok(univSerivce.CertCode(univCertCodeDto));
   }
-
 
 }
 

--- a/src/main/java/gitbal/backend/api/univcert/dto/UnivCertCodeDto.java
+++ b/src/main/java/gitbal/backend/api/univcert/dto/UnivCertCodeDto.java
@@ -8,16 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Getter
 public class UnivCertCodeDto {
-
   private String email;
   private String univName;
   private Integer code;
-
-  @Builder
-  UnivCertCodeDto(String email, String univName, Integer code) {
-    this.email = email;
-    this.univName = univName;
-    this.code = code;
-  }
-
 }

--- a/src/main/java/gitbal/backend/api/univcert/dto/UnivCertResponseDto.java
+++ b/src/main/java/gitbal/backend/api/univcert/dto/UnivCertResponseDto.java
@@ -1,0 +1,20 @@
+package gitbal.backend.api.univcert.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class UnivCertResponseDto {
+  private int status;
+  private boolean success;
+  private String message;
+
+  public UnivCertResponseDto(int status, boolean success, String message) {
+    this.status = status;
+    this.success = success;
+    this.message = message;
+  }
+}

--- a/src/main/java/gitbal/backend/api/univcert/dto/UnivCertStartDto.java
+++ b/src/main/java/gitbal/backend/api/univcert/dto/UnivCertStartDto.java
@@ -8,14 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
 @Getter
 public class UnivCertStartDto {
-
   private String email;
   private String univName;
-
-  @Builder
-  UnivCertStartDto(String email, String univName) {
-    this.email = email;
-    this.univName = univName;
-  }
-
 }

--- a/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
+++ b/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
@@ -23,7 +23,7 @@ public class UnivService {
       Map<String, Object> response = UnivCert.certify(apikey, univCertStartDto.getEmail(), univCertStartDto.getUnivName(), true);
       return responsetoDto(response, "인증번호 전송 완료");
     } catch (Exception e) {
-      throw new UnivCertStartException(e.getMessage());
+      throw new UnivCertStartException();
     }
   }
 

--- a/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
+++ b/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
@@ -3,6 +3,8 @@ package gitbal.backend.api.univcert.service;
 import com.univcert.api.UnivCert;
 import gitbal.backend.api.univcert.dto.UnivCertCodeDto;
 import gitbal.backend.api.univcert.dto.UnivCertStartDto;
+import gitbal.backend.global.exception.UnivCertCodeException;
+import gitbal.backend.global.exception.UnivCertStartException;
 import java.io.IOException;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,36 +16,21 @@ public class UnivService {
   @Value("${API-KEY}")
   private String apikey;
 
-  public Map<String, Object> CertStart(UnivCertStartDto univCertStartDto) throws IOException {
-    String email = univCertStartDto.getEmail();
-    String univName = univCertStartDto.getUnivName();
-
-    return UnivCert.certify(apikey, email, univName, true);
-  }
-
-  public Map<String, Object> CertCode(UnivCertCodeDto univCertCodeDto)
-      throws IOException {
-    String email = univCertCodeDto.getEmail();
-    String univName = univCertCodeDto.getUnivName();
-    Integer code = univCertCodeDto.getCode();
-
-    //TODO : certifiCode에서 보내주는 return값이 더 깔끔한데, 따로 형식을 만들어서 response를 줄건지
-    /*
-    Map<String, Object> jsonResponse = UnivCert.certifyCode(apikey, email, univName,code);
-    boolean success = jsonResponse.containsKey("\"success\": true");
-
-    if (success) {
-      return ResponseEntity.status(HttpStatus.OK).body("인증번호 검증을 성공했습니다.");
-    }else {
-      JSONObject jsonObject = new JSONObject(jsonResponse);
-      String message = jsonObject.getString("message");
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
+  public Map<String, Object> CertStart(UnivCertStartDto univCertStartDto){
+    try {
+      return UnivCert.certify(apikey, univCertStartDto.getEmail(),univCertStartDto.getUnivName(), true);
+    } catch (Exception e) {
+      throw new UnivCertStartException();
     }
 
-     */
+  }
 
-    return UnivCert.certifyCode(apikey, email, univName, code);
-
+  public Map<String, Object> CertCode(UnivCertCodeDto univCertCodeDto) {
+    try {
+      return UnivCert.certifyCode(apikey, univCertCodeDto.getEmail(), univCertCodeDto.getUnivName(), univCertCodeDto.getCode());
+    } catch (Exception e) {
+      throw new UnivCertCodeException();
+    }
   }
 }
 

--- a/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
+++ b/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
@@ -2,13 +2,15 @@ package gitbal.backend.api.univcert.service;
 
 import com.univcert.api.UnivCert;
 import gitbal.backend.api.univcert.dto.UnivCertCodeDto;
+import gitbal.backend.api.univcert.dto.UnivCertResponseDto;
 import gitbal.backend.api.univcert.dto.UnivCertStartDto;
 import gitbal.backend.global.exception.UnivCertCodeException;
 import gitbal.backend.global.exception.UnivCertStartException;
-import java.io.IOException;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class UnivService {
@@ -16,21 +18,34 @@ public class UnivService {
   @Value("${API-KEY}")
   private String apikey;
 
-  public Map<String, Object> CertStart(UnivCertStartDto univCertStartDto){
+  public UnivCertResponseDto certStart(UnivCertStartDto univCertStartDto){
     try {
-      return UnivCert.certify(apikey, univCertStartDto.getEmail(),univCertStartDto.getUnivName(), true);
+      Map<String, Object> response = UnivCert.certify(apikey, univCertStartDto.getEmail(), univCertStartDto.getUnivName(), true);
+      return responsetoDto(response, "인증번호 전송 완료");
     } catch (Exception e) {
-      throw new UnivCertStartException();
+      throw new UnivCertStartException(e.getMessage());
     }
-
   }
 
-  public Map<String, Object> CertCode(UnivCertCodeDto univCertCodeDto) {
+  public UnivCertResponseDto certCode(UnivCertCodeDto univCertCodeDto) {
     try {
-      return UnivCert.certifyCode(apikey, univCertCodeDto.getEmail(), univCertCodeDto.getUnivName(), univCertCodeDto.getCode());
+      Map<String, Object> response = UnivCert.certifyCode(apikey, univCertCodeDto.getEmail(), univCertCodeDto.getUnivName(), univCertCodeDto.getCode());
+      return responsetoDto(response, "인증 성공");
+
     } catch (Exception e) {
       throw new UnivCertCodeException();
     }
   }
-}
 
+  private UnivCertResponseDto responsetoDto(Map<String, Object> univCertResponse, String successMessage) {
+    boolean success = Boolean.TRUE.equals(univCertResponse.get("success"));
+    int status = success ? 200 : (Integer) univCertResponse.get("code");
+    String message = success ? successMessage : (String) univCertResponse.get("message");
+
+    return UnivCertResponseDto.builder()
+        .status(status)
+        .success(success)
+        .message(message)
+        .build();
+  }
+}

--- a/src/main/java/gitbal/backend/domain/school/SchoolService.java
+++ b/src/main/java/gitbal/backend/domain/school/SchoolService.java
@@ -5,8 +5,10 @@ import gitbal.backend.global.exception.NotFoundSchoolException;
 import gitbal.backend.global.util.SurroundingRankStatus;
 import gitbal.backend.domain.user.UserRepository;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,6 +20,7 @@ public class SchoolService {
   private final int SCHOOL_AROUND_RANGE = 3;
   private final SchoolRepository schoolRepository;
   private final UserRepository userRepository;
+  private final int FIRST_RANK = 1;
 
   public School findBySchoolName(String schoolName) {
     return schoolRepository.findBySchoolName(schoolName)
@@ -55,11 +58,25 @@ public class SchoolService {
         }
       }
     }
-
   }
 
   public void updateByUserScore(School school, String username, Long oldScore, Long newScore) {
     school.updateScore(oldScore,newScore);
     school.updateContributerInfo(username, newScore);
+  }
+
+  public void updateSchoolRank(){
+    List<School> schools = schoolRepository.findAll(Sort.by("score").descending());
+    int rank = FIRST_RANK;
+    int prevRank = FIRST_RANK;
+    for (int i = 0; i < schools.size(); i++) {
+      School school = schools.get(i);
+      if (i > 0 && !Objects.equals(schools.get(i - 1).getScore(), school.getScore())) {
+        prevRank = rank;
+      }
+      school.setSchoolRank(prevRank);
+      schoolRepository.save(school);
+      rank = prevRank + 1;
+    }
   }
 }

--- a/src/main/java/gitbal/backend/domain/user/UserService.java
+++ b/src/main/java/gitbal/backend/domain/user/UserService.java
@@ -26,6 +26,7 @@ public class UserService {
     private final UserInfoService userInfoService;
     private final UserRepository userRepository;
     private final int USER_AROUND_RANGE = 2;
+    private final int FIRST_RANK = 1;
 
 
     public Long calculateUserScore(String nickname) {
@@ -143,10 +144,24 @@ public class UserService {
         }
     }
 
-
     public List<MajorLanguage> findMajorLanguagesByUsername(String username) {
         User findUser = userRepository.findByNickname(username)
             .orElseThrow(NotFoundUserException::new);
         return findUser.getMajorLanguages();
+    }
+
+    public void updateUserRank() {
+        List<User> users = userRepository.findAll(Sort.by("score").descending());
+        int rank = FIRST_RANK;
+        int prevRank = FIRST_RANK;
+        for (int i = 0; i < users.size(); i++) {
+            User user = users.get(i);
+            if (i > 0 && users.get(i - 1).getScore() != user.getScore()) {
+                prevRank = rank;
+            }
+            user.setUserRank(prevRank);
+            userRepository.save(user);
+            rank = prevRank + 1;
+        }
     }
 }

--- a/src/main/java/gitbal/backend/global/exception/UnivCertCodeException.java
+++ b/src/main/java/gitbal/backend/global/exception/UnivCertCodeException.java
@@ -1,0 +1,8 @@
+package gitbal.backend.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class UnivCertCodeException extends RuntimeException{
+  public UnivCertCodeException() {super("번호 인증에 실패했습니다.");}
+}

--- a/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
+++ b/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
@@ -4,5 +4,5 @@ import lombok.experimental.StandardException;
 
 @StandardException
 public class UnivCertStartException extends RuntimeException {
-  public UnivCertStartException(Error e) {super("인증번호 발송에 실패했습니다." + e.getMessage());}
+  public UnivCertStartException(Error e) {super("인증번호 발송에 실패했습니다.");}
 }

--- a/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
+++ b/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
@@ -1,0 +1,8 @@
+package gitbal.backend.global.exception;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class UnivCertStartException extends RuntimeException {
+  public UnivCertStartException() {super("인증번호 발송에 실패했습니다.");}
+}

--- a/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
+++ b/src/main/java/gitbal/backend/global/exception/UnivCertStartException.java
@@ -4,5 +4,5 @@ import lombok.experimental.StandardException;
 
 @StandardException
 public class UnivCertStartException extends RuntimeException {
-  public UnivCertStartException() {super("인증번호 발송에 실패했습니다.");}
+  public UnivCertStartException(Error e) {super("인증번호 발송에 실패했습니다." + e.getMessage());}
 }

--- a/src/main/java/gitbal/backend/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gitbal/backend/global/handler/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import gitbal.backend.global.exception.NotFoundSchoolException;
 import gitbal.backend.global.exception.NotFoundUserException;
 import gitbal.backend.global.exception.NotLoginedException;
 import gitbal.backend.global.exception.PageOutOfRangeException;
+import gitbal.backend.global.exception.UnivCertCodeException;
+import gitbal.backend.global.exception.UnivCertStartException;
 import gitbal.backend.global.exception.UserRankException;
 import gitbal.backend.global.exception.WrongPageNumberException;
 import org.springframework.http.ResponseEntity;
@@ -86,6 +88,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoTokenException.class)
     public  ResponseEntity<String> handleNoTokenException(NoTokenException e){
+        return ResponseEntity.status(400).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnivCertStartException.class)
+    public ResponseEntity<String> handleUnivCertStartException(UnivCertStartException e) {
+        return ResponseEntity.status(400).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnivCertCodeException.class)
+    public ResponseEntity<String> handleUnivCertCodeException(UnivCertCodeException e) {
         return ResponseEntity.status(400).body(e.getMessage());
     }
 

--- a/src/main/java/gitbal/backend/schedule/SchedulingService.java
+++ b/src/main/java/gitbal/backend/schedule/SchedulingService.java
@@ -3,6 +3,7 @@ package gitbal.backend.schedule;
 import gitbal.backend.schedule.userupdate.majorLanguage.UserLanguagesUpdater;
 import gitbal.backend.schedule.userupdate.onedaycommit.UserOneDayCommitUpdater;
 import gitbal.backend.schedule.userupdate.score.UserScoreUpdater;
+import gitbal.backend.schedule.userupdate.userRank.RankUpdater;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ public class SchedulingService {
     private final UserOneDayCommitUpdater userOneDayCommitUpdater;
     private final UserScoreUpdater userScoreUpdater;
     private final UserLanguagesUpdater userLanguagesUpdater;
+    private final RankUpdater rankUpdater;
 
 
     @Scheduled(initialDelay = 2, fixedRate = 360, timeUnit = TimeUnit.MINUTES)
@@ -31,5 +33,6 @@ public class SchedulingService {
     @Scheduled(initialDelay = 2, fixedRate = 360, timeUnit = TimeUnit.MINUTES)
     public void updateUserLanguages(){userLanguagesUpdater.update();}
 
-
+    @Scheduled(initialDelay = 3, fixedRate = 360, timeUnit = TimeUnit.MINUTES)
+    public void updateRanks(){rankUpdater.update();}
 }

--- a/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdater.java
+++ b/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdater.java
@@ -1,0 +1,7 @@
+package gitbal.backend.schedule.userupdate.userRank;
+
+public interface RankUpdater {
+
+  void update();
+
+}

--- a/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdaterImpl.java
+++ b/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdaterImpl.java
@@ -1,48 +1,30 @@
 package gitbal.backend.schedule.userupdate.userRank;
 
 import gitbal.backend.domain.school.School;
+import gitbal.backend.domain.school.SchoolService;
 import gitbal.backend.domain.user.User;
 import gitbal.backend.domain.user.UserRepository;
+import gitbal.backend.domain.user.UserService;
+import gitbal.backend.schedule.userupdate.UserSetup;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class RankUpdaterImpl implements RankUpdater {
+public class RankUpdaterImpl extends UserSetup implements RankUpdater {
 
-  private UserRepository userRepository;
+  private final UserService userService;
+  private final SchoolService schoolService;
 
   @Override
+  @Transactional
   public void update() {
-    List<User> users = userRepository.findAll(Sort.by("score").descending());
-    int rank = 1;
-    int prevRank = 1;
-    for (int i = 0; i < users.size(); i++) {
-      User user = users.get(i);
-      if (i > 0 && users.get(i - 1).getScore() != user.getScore()) {
-        prevRank = rank;
-      }
-      user.setUserRank(prevRank);
-      userRepository.save(user);
-      rank = prevRank + 1;
-    }
-  }
-
-
-
-  private void scoreRankingCalculate(List< School > schools, int rank) {
-    int prevRank = rank;
-    for (int i = 0; i < schools.size(); i++) {
-      School school = schools.get(i);
-      if (i > 0 && schools.get(i - 1).getScore() != school.getScore()) {
-        prevRank = rank;
-      }
-      school.setSchoolRank(prevRank);
-      rank = prevRank + 1;
-    }
+    userService.updateUserRank();
+    schoolService.updateSchoolRank();
   }
 }

--- a/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdaterImpl.java
+++ b/src/main/java/gitbal/backend/schedule/userupdate/userRank/RankUpdaterImpl.java
@@ -1,0 +1,48 @@
+package gitbal.backend.schedule.userupdate.userRank;
+
+import gitbal.backend.domain.school.School;
+import gitbal.backend.domain.user.User;
+import gitbal.backend.domain.user.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RankUpdaterImpl implements RankUpdater {
+
+  private UserRepository userRepository;
+
+  @Override
+  public void update() {
+    List<User> users = userRepository.findAll(Sort.by("score").descending());
+    int rank = 1;
+    int prevRank = 1;
+    for (int i = 0; i < users.size(); i++) {
+      User user = users.get(i);
+      if (i > 0 && users.get(i - 1).getScore() != user.getScore()) {
+        prevRank = rank;
+      }
+      user.setUserRank(prevRank);
+      userRepository.save(user);
+      rank = prevRank + 1;
+    }
+  }
+
+
+
+  private void scoreRankingCalculate(List< School > schools, int rank) {
+    int prevRank = rank;
+    for (int i = 0; i < schools.size(); i++) {
+      School school = schools.get(i);
+      if (i > 0 && schools.get(i - 1).getScore() != school.getScore()) {
+        prevRank = rank;
+      }
+      school.setSchoolRank(prevRank);
+      rank = prevRank + 1;
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
#120 
## 📝작업 내용
스케줄러에서 랭킹을 업데이트 하지 못하던 이슈 수정

UserService, SchoolService에 랭킹 업데이트 함수 추가, 이를 RankUpdaterImpl이 불러와서 사용하도록

학교와 유저의 랭킹 업데이트를 점수 업데이트가 끝난 이후 진행하도록 initialDelay 1분 늦게 적용,  트랜잭션 처리
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)
업데이트 전
![캡처2](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/d3867da4-b2db-426a-bb85-9ff7a7bf7e34)

업데이트 후
![업데이트 후](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/138199219/25b998bb-0149-44e5-9b49-5264c5b373e1)


랭킹까지 수정되는 걸 확인.

또한 학교의 경우도 테스트 중 랭킹 업데이트가 반영되는 걸 확인하였으나 한 유저만 지정해서 업데이트 되는 지금의 테스트 코드 특성 상, 학교 순위의 변동이 있을 확률이 낮아 캡쳐는 하지 못했습니다.
## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..
