### PR TITLE
[fix] - 잘못 응답이 갔던 myRegionRank 관련한 수정작업

### DIFF
--- a/src/main/java/gitbal/backend/api/regionPage/service/RegionRankService.java
+++ b/src/main/java/gitbal/backend/api/regionPage/service/RegionRankService.java
@@ -3,16 +3,19 @@ package gitbal.backend.api.regionPage.service;
 
 import gitbal.backend.api.regionPage.dto.RegionListPageResponseDto;
 import gitbal.backend.domain.region.Region;
+import gitbal.backend.domain.school.School;
 import gitbal.backend.domain.user.User;
 import gitbal.backend.api.regionPage.dto.FirstRankRegionDto;
 import gitbal.backend.api.regionPage.dto.MyRegionInfoResponseDto;
 import gitbal.backend.api.regionPage.dto.RegionListDto;
+import gitbal.backend.global.exception.NotFoundRegionException;
 import gitbal.backend.global.exception.NotFoundUserException;
 import gitbal.backend.global.exception.NotLoginedException;
 import gitbal.backend.domain.region.RegionRepository;
 import gitbal.backend.domain.user.UserRepository;
 import gitbal.backend.global.security.CustomUserDetails;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -85,7 +88,17 @@ public class RegionRankService {
             NotFoundUserException::new
         );
         Region region = user.getRegion();
-        return MyRegionInfoResponseDto.of(regionRepository.getRegionRanking(region.getRegionName()),
-            region);
+
+        return MyRegionInfoResponseDto.of(findRegionRank(region.getRegionName()), region);
+    }
+
+    //TODO: 이후에 school, region 관련하여서 더 생각해보기
+    private int findRegionRank(String regionName){
+        List<Region> regions = regionRepository.findAll(Sort.by("score").descending());
+        for (int i = 0; i < regions.size(); i++) {
+            Region region = regions.get(i);
+            if(region.getRegionName().equals(regionName))  return i+1;
+        }
+        throw new NotFoundRegionException();
     }
 }

--- a/src/main/java/gitbal/backend/domain/region/RegionRepository.java
+++ b/src/main/java/gitbal/backend/domain/region/RegionRepository.java
@@ -12,7 +12,6 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
 
     Optional<Region> findByRegionName(String regionName);
 
-
     @Query("SELECT count(r) FROM Region r WHERE r.score > :regionScore")
     int regionScoreRacedForward(@Param("regionScore") Long regionScore);
 
@@ -30,6 +29,4 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
     @Query("SELECT r FROM Region r ORDER BY r.score DESC LIMIT 1")
     Region firstRankedRegion();
 
-    @Query(value = "SELECT RANK() OVER (ORDER BY score DESC) AS `rank` FROM region where region_name = :regionName", nativeQuery = true)
-    int getRegionRanking(String regionName);
 }

--- a/src/main/java/gitbal/backend/domain/school/SchoolRepository.java
+++ b/src/main/java/gitbal/backend/domain/school/SchoolRepository.java
@@ -34,7 +34,4 @@ public interface SchoolRepository extends JpaRepository<School, Long> {
 
   Page<School> findBySchoolNameContainingIgnoreCase(String searchedSchoolName, Pageable pageable);
 
-
-  @Query(value = "SELECT RANK() OVER (ORDER BY score DESC) AS `rank` FROM school WHERE school_name = :schoolName", nativeQuery = true)
-  int getSchoolRanking(String schoolName);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#132 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

fe로의 myRegionRank 관련하여 요청이 오게 되어서 확인해봤고 정상적으로 내 지역 랭크 값이 반환될 수 있도록 수정작업 진행했습니다.

- 오류 이유 : 이전에 작성되었던 쿼리를 사용했었는데 
`SELECT RANK() OVER (ORDER BY score DESC) AS `rank`
FROM region
WHERE region_name = :regionName`

이 쿼리의 경우 어짜피 where문이 처음 작동하면 한 행만 보게 되어서 무조건 1위만 나가게 되는 것이었습니다.
그래서 애초에 지역의 경우 최대 10개 지역으로 분류하였기에 애플리케이션 차원에서 랭크 계산에서 나갈 수 있도록 변경하였습니다.
- 추가적으로 이 잘못된 쿼리가 작성되어있었던 `schoolRepository`의 코드 일부를 삭제했습니다.

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)

![image](https://github.com/capstone-kw-jjiggle/gitbal-be/assets/38220795/be8ce47b-761f-454a-8c37-96c6b62b918c)


## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..


closes #132 
