### PR TITLE
[feat] #144 - 학교 인증 처리할때 인증 성공했을 경우 인증 리스트 초기화 하여 이후 회원탈퇴에도 문제 없게 진행

### DIFF
--- a/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
+++ b/src/main/java/gitbal/backend/api/univcert/service/UnivService.java
@@ -6,13 +6,16 @@ import gitbal.backend.api.univcert.dto.UnivCertResponseDto;
 import gitbal.backend.api.univcert.dto.UnivCertStartDto;
 import gitbal.backend.global.exception.UnivCertCodeException;
 import gitbal.backend.global.exception.UnivCertStartException;
+import java.io.IOException;
+import java.util.HashMap;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @Service
+@Slf4j
 public class UnivService {
 
   @Value("${API-KEY}")
@@ -30,11 +33,21 @@ public class UnivService {
   public UnivCertResponseDto certCode(UnivCertCodeDto univCertCodeDto) {
     try {
       Map<String, Object> response = UnivCert.certifyCode(apikey, univCertCodeDto.getEmail(), univCertCodeDto.getUnivName(), univCertCodeDto.getCode());
-      return responsetoDto(response, "인증 성공");
 
+      clearCertifiedList(response, univCertCodeDto.getEmail());
+
+      return responsetoDto(response, "인증 성공");
     } catch (Exception e) {
       throw new UnivCertCodeException();
     }
+  }
+
+  private void clearCertifiedList(Map<String, Object> response, String email) throws IOException {
+    Map<String, Object> clear = new HashMap<>();
+    if(Boolean.TRUE.equals(response.get("success")))  clear = UnivCert.clear(apikey,email);
+    else log.info("[clearResponse] 인증 과정에서 코드가 맞지 않아 clear하지 않았습니다.");
+    if(Boolean.TRUE.equals(clear.get("success")))  log.info("[clearResponse] clear success");
+    else log.error("[clearResponse] clear fail");
   }
 
   private UnivCertResponseDto responsetoDto(Map<String, Object> univCertResponse, String successMessage) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#144 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 해당 작업을 통해서 대학교 다시 인증코드 잘못 입력한 경우는 다시 보낼 수 있게
- 인증 성공한 경우 인증 리스트에서 제거하여 이후에 메일 보낼 수 있도록 처리

### 코드 실행시 - 스크린샷(필수 x, jira 대체 가능)

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 어떻게 코드를 더 개선할 수 있을까? 이름 추천 등등..
